### PR TITLE
Handle UITableView operations properly when performing not animated

### DIFF
--- a/Sources/Concrete/TableViewOperationsManager.swift
+++ b/Sources/Concrete/TableViewOperationsManager.swift
@@ -1,6 +1,5 @@
 //
 //  TableViewOperationsManager.swift
-//  CoMotion
 //
 //  Created by Corneliu on 20/04/2017.
 //  Copyright © 2017 CoMotion. All rights reserved.
@@ -39,16 +38,16 @@ class TableViewOperationsManager<H, R: HeightFlexible>: TableViewModelDelegate {
     }
     
     func didUpdateSection(at index: Int, in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let section = IndexSet(integer: index)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        tableView?.reloadSections(section, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            let section = IndexSet(integer: index)
+            self?.tableView?.reloadSections(section, with: rowAnimation)
+        }
     }
     
     func didRemove(itemsFrom indexPaths: [IndexPath], in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        tableView?.deleteRows(at: indexPaths, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            self?.tableView?.deleteRows(at: indexPaths, with: rowAnimation)
+        }
     }
     
     func didUpdate(itemsAt indexPaths: [IndexPath], in tableViewModel: AnyTableViewModel<H, R>) {
@@ -62,25 +61,26 @@ class TableViewOperationsManager<H, R: HeightFlexible>: TableViewModelDelegate {
     }
     
     func didReplace(itemsAt indexPaths: [IndexPath], in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        self.tableView?.reloadRows(at: indexPaths, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            self?.tableView?.reloadRows(at: indexPaths, with: rowAnimation)
+        }
     }
     
     func didInsertSections(at indexes: [Int], in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let indexSet = NSMutableIndexSet()
-        indexes.forEach(indexSet.add)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        self.tableView?.insertSections(indexSet as IndexSet, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            let indexSet = NSMutableIndexSet()
+            indexes.forEach(indexSet.add)
+            self?.tableView?.insertSections(indexSet as IndexSet, with: rowAnimation)
+        }
+        
     }
     
     func didRemoveSections(at indexes: [Int], in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let indexSet = NSMutableIndexSet()
-        indexes.forEach(indexSet.add)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        self.tableView?.deleteSections(indexSet as IndexSet, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            let indexSet = NSMutableIndexSet()
+            indexes.forEach(indexSet.add)
+            self?.tableView?.deleteSections(indexSet as IndexSet, with: rowAnimation)
+        }
     }
     
     func didUpdateHeights(in tableViewModel: AnyTableViewModelType) {
@@ -90,13 +90,21 @@ class TableViewOperationsManager<H, R: HeightFlexible>: TableViewModelDelegate {
     }
     
     func didInsert(itemsAt indexPaths: [IndexPath], in tableViewModel: AnyTableViewModel<H, R>, animated: Bool) {
-        updateData(from: tableViewModel)
-        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
-        self.tableView?.insertRows(at: indexPaths, with: rowAnimation)
+        prepareTableView(tableViewModel: tableViewModel, animated: animated) { [weak self] (rowAnimation) in
+            self?.tableView?.insertRows(at: indexPaths, with: rowAnimation)
+        }
     }
     
     func scrollTo(indexPath: IndexPath, animated: Bool) {
         tableView?.scrollToRow(at: indexPath, at: .bottom, animated: animated)
     }
-
+    
+    private func prepareTableView(tableViewModel: AnyTableViewModel<H, R>, animated: Bool, completion: @escaping (_ rowAnimation: UITableViewRowAnimation) -> Void) {
+        updateData(from: tableViewModel)
+        let rowAnimation = animated ? UITableViewRowAnimation.automatic : .none
+        UIView.setAnimationsEnabled(false)
+        completion(rowAnimation)
+        UIView.setAnimationsEnabled(true)
+    }
+    
 }


### PR DESCRIPTION
This issue is regarded to this SDK bug: https://stackoverflow.com/questions/13920699/insert-uitableview-row-without-any-animation